### PR TITLE
remove nonused deprecated resources

### DIFF
--- a/_provider.tf
+++ b/_provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  alias = "peer"
-}

--- a/_version.tf
+++ b/_version.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.76.1"
+      configuration_aliases = [
+        aws.peer,
+      ]
+    }
+  }
+  required_version = ">= 0.13"
+}
+


### PR DESCRIPTION
Fixed warning deprecated:

```
Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Redundant empty provider block
│
│   on .terraform/modules/vpc_peer_nonprod/_provider.tf line 1:
│    1: provider "aws" {
│
│ Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.
│
│ If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "aws" blocks and then adding or updating an entry like the following to the required_providers block of module.vpc_peer_nonprod:
│     aws = {
│       source = "hashicorp/aws"
│       configuration_aliases = [
│         aws.peer,
│       ]
│     }
│
│ (and 3 more similar warnings elsewhere)
```